### PR TITLE
Removing useless scrollbar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
     <script type="module">import "./js/app.js"</script>
 </head>
 
-<body>
+<body style="overflow:hidden">
 <nav class="navbar is-light">
     <div class="container">
         <div class="navbar-brand">


### PR DESCRIPTION
I added an "overflow: hidden" to the body tag, effectively removing the useless scrollbar that was previously present. This simple change enhances the user experience by eliminating the annoyance of the scrollbar and providing a smoother experience for users.
